### PR TITLE
🐛 Disable HTTP write timeout for audio streaming

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,7 @@ func LoadConfig() (*Config, error) {
 	// Server flags
 	serverPort := flag.String("port", "", "Server port (default: 8080)")
 	readTimeout := flag.String("read-timeout", "", "HTTP read timeout (default: 15s)")
-	writeTimeout := flag.String("write-timeout", "", "HTTP write timeout (default: 15s)")
+	writeTimeout := flag.String("write-timeout", "", "HTTP write timeout (default: 0, disabled for streaming)")
 	idleTimeout := flag.String("idle-timeout", "", "HTTP idle timeout (default: 60s)")
 	advertiseMDNS := flag.String("advertise-mdns", "", "Advertise via mDNS/Zeroconf (default: true)")
 
@@ -188,7 +188,7 @@ func LoadConfig() (*Config, error) {
 	}
 	cfg.Server.ReadTimeout = readTimeoutDuration
 
-	writeTimeoutStr := getConfigValue(*writeTimeout, "SERVER_WRITE_TIMEOUT", "15s")
+	writeTimeoutStr := getConfigValue(*writeTimeout, "SERVER_WRITE_TIMEOUT", "0s")
 	writeTimeoutDuration, err := time.ParseDuration(writeTimeoutStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid write timeout %q: %w", writeTimeoutStr, err)


### PR DESCRIPTION
## Problem

Default `WriteTimeout` of 15s on `http.Server` kills large file downloads/streams after ~30MB at typical transfer speeds (~2MB/s over Tailscale).

Go's `http.Server.WriteTimeout` is a hard deadline on the **entire response write**, not an idle timeout. For an audiobook server streaming files up to 1GB+, 15 seconds is far too short.

## Fix

Change default from `15s` to `0s` (disabled). Can still be overridden via `SERVER_WRITE_TIMEOUT` env var or `--write-timeout` flag.

## Impact

- Fixes iOS and desktop downloads that were consistently failing at ~30MB
- Fixes curl downloads from any client
- AVPlayer streaming was unaffected because it uses Range requests (each chunk completes within 15s)