### PR TITLE
✨ Async analysis endpoint with progress tracking

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/listenupapp/listenup-server/internal/backup"
+	"github.com/listenupapp/listenup-server/internal/backup/abs"
 	"github.com/listenupapp/listenup-server/internal/domain"
 	"github.com/listenupapp/listenup-server/internal/sse"
 	"github.com/listenupapp/listenup-server/internal/store"
@@ -32,6 +33,7 @@ type Server struct {
 	authRateLimiter           *RateLimiter
 	backupService             *backup.BackupService
 	restoreService            *backup.RestoreService
+	analysisTracker           *abs.AnalysisTracker
 	onInstanceUpdated         func(*domain.Instance)
 }
 
@@ -96,6 +98,7 @@ func NewServer(
 		authRateLimiter:           NewRateLimiter(20, time.Minute, 10),
 		backupService:             backupSvc,
 		restoreService:            restoreSvc,
+		analysisTracker:           abs.NewAnalysisTracker(),
 	}
 
 	s.registerRoutes()

--- a/internal/backup/abs/analysis_tracker.go
+++ b/internal/backup/abs/analysis_tracker.go
@@ -1,0 +1,129 @@
+package abs
+
+import (
+	"sync"
+	"time"
+)
+
+// AnalysisPhase represents the current phase of analysis.
+type AnalysisPhase string
+
+const (
+	PhaseParsing          AnalysisPhase = "parsing"
+	PhaseMatchingUsers    AnalysisPhase = "matching_users"
+	PhaseMatchingBooks    AnalysisPhase = "matching_books"
+	PhaseMatchingSessions AnalysisPhase = "matching_sessions"
+	PhaseMatchingProgress AnalysisPhase = "matching_progress"
+	PhaseDone             AnalysisPhase = "done"
+)
+
+// AnalysisStatus represents the overall status of an async analysis.
+type AnalysisStatus string
+
+const (
+	StatusRunning   AnalysisStatus = "running"
+	StatusCompleted AnalysisStatus = "completed"
+	StatusFailed    AnalysisStatus = "failed"
+)
+
+// AnalysisProgress tracks the progress of an async analysis.
+type AnalysisProgress struct {
+	mu      sync.RWMutex
+	Status  AnalysisStatus `json:"status"`
+	Phase   AnalysisPhase  `json:"phase"`
+	Current int            `json:"current"`
+	Total   int            `json:"total"`
+	Result  interface{}    `json:"result,omitempty"`
+	Error   string         `json:"error,omitempty"`
+}
+
+// Update sets the current progress phase and counts.
+func (p *AnalysisProgress) Update(phase AnalysisPhase, current, total int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Phase = phase
+	p.Current = current
+	p.Total = total
+}
+
+// Complete marks the analysis as completed with a result.
+func (p *AnalysisProgress) Complete(result interface{}) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Status = StatusCompleted
+	p.Phase = PhaseDone
+	p.Result = result
+}
+
+// Fail marks the analysis as failed with an error message.
+func (p *AnalysisProgress) Fail(err string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Status = StatusFailed
+	p.Error = err
+}
+
+// Snapshot returns a copy of the current progress state.
+func (p *AnalysisProgress) Snapshot() AnalysisProgress {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return AnalysisProgress{
+		Status:  p.Status,
+		Phase:   p.Phase,
+		Current: p.Current,
+		Total:   p.Total,
+		Result:  p.Result,
+		Error:   p.Error,
+	}
+}
+
+// ProgressCallback is called by the analyzer to report progress.
+type ProgressCallback func(phase AnalysisPhase, current, total int)
+
+// AnalysisTracker manages in-flight async analyses.
+type AnalysisTracker struct {
+	mu       sync.RWMutex
+	analyses map[string]*AnalysisProgress
+}
+
+// NewAnalysisTracker creates a new tracker.
+func NewAnalysisTracker() *AnalysisTracker {
+	return &AnalysisTracker{
+		analyses: make(map[string]*AnalysisProgress),
+	}
+}
+
+// Start creates a new tracked analysis and returns its progress.
+func (t *AnalysisTracker) Start(id string) *AnalysisProgress {
+	progress := &AnalysisProgress{
+		Status: StatusRunning,
+		Phase:  PhaseParsing,
+	}
+	t.mu.Lock()
+	t.analyses[id] = progress
+	t.mu.Unlock()
+	return progress
+}
+
+// Get returns the progress for an analysis, or nil if not found.
+func (t *AnalysisTracker) Get(id string) *AnalysisProgress {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.analyses[id]
+}
+
+// Cleanup removes completed analyses older than the given duration.
+func (t *AnalysisTracker) Cleanup(maxAge time.Duration) {
+	// Simple approach: remove all completed/failed analyses
+	// In practice, completed analyses are fetched once and then
+	// the client moves on to the import hub.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for id, p := range t.analyses {
+		snap := p.Snapshot()
+		if snap.Status == StatusCompleted || snap.Status == StatusFailed {
+			delete(t.analyses, id)
+		}
+	}
+	_ = maxAge // reserved for future time-based cleanup
+}


### PR DESCRIPTION
## Changes

Adds async analysis with progress polling for ABS import.

**New endpoints:**
- `POST /api/v1/admin/abs/analyze/async` — starts background analysis, returns analysis_id
- `GET /api/v1/admin/abs/analyze/{id}/status` — polls progress (phase, current/total, result when done)

**New files:**
- `analysis_tracker.go` — thread-safe progress tracking with in-memory state

**Modified:**
- `analyzer.go` — WithProgress() builder, reports phase progress during analysis
- `admin_abs_handlers.go` — extracted buildAnalyzeResponse helper, new async handlers
- `server.go` — added analysisTracker field

Companion to ListenUpApp/client PR (feat/analyze-progress)