### PR TITLE
🛡️ Add HTTP request validation across API handlers

### DIFF
--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -305,7 +305,7 @@ type SetOpenRegistrationInput struct {
 type SearchUsersInput struct {
 	Authorization string `header:"Authorization"`
 	Query         string `query:"q" doc:"Search query (matches email, display name, first/last name)"`
-	Limit         int    `query:"limit" default:"10" doc:"Maximum number of results to return"`
+	Limit         int    `query:"limit" default:"10" minimum:"1" maximum:"50" doc:"Maximum number of results to return"`
 }
 
 // UserSearchResult is a single user search result.

--- a/internal/api/book_handlers.go
+++ b/internal/api/book_handlers.go
@@ -329,9 +329,11 @@ func (s *Server) handleListBooks(ctx context.Context, input *ListBooksInput) (*L
 		Cursor: input.Cursor,
 	}
 	if input.UpdatedAfter != "" {
-		if t, err := time.Parse(time.RFC3339, input.UpdatedAfter); err == nil {
-			params.UpdatedAfter = t
+		t, err := time.Parse(time.RFC3339, input.UpdatedAfter)
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid updated_after format, expected RFC3339")
 		}
+		params.UpdatedAfter = t
 	}
 
 	result, err := s.services.Book.ListBooks(ctx, userID, params)

--- a/internal/api/contributor_handlers.go
+++ b/internal/api/contributor_handlers.go
@@ -128,7 +128,7 @@ func (s *Server) registerContributorRoutes() {
 type ListContributorsInput struct {
 	Authorization string `header:"Authorization"`
 	Cursor        string `query:"cursor" doc:"Pagination cursor"`
-	Limit         int    `query:"limit" doc:"Items per page (default 50)"`
+	Limit         int    `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Items per page"`
 }
 
 // ContributorResponse contains contributor data in API responses.
@@ -284,7 +284,7 @@ type SearchContributorsOutput struct {
 
 // ApplyContributorMetadataRequest is the request body for applying Audible metadata to a contributor.
 type ApplyContributorMetadataRequest struct {
-	ASIN     string                    `json:"asin" doc:"Audible ASIN"`
+	ASIN     string                    `json:"asin" validate:"required" doc:"Audible ASIN"`
 	ImageURL string                    `json:"image_url,omitempty" doc:"Image URL from search results"`
 	Fields   ContributorMetadataFields `json:"fields" doc:"Which fields to apply"`
 }

--- a/internal/api/listening_handlers.go
+++ b/internal/api/listening_handlers.go
@@ -274,7 +274,7 @@ type RestartBookOutput struct {
 // GetContinueListeningInput contains parameters for getting continue listening items.
 type GetContinueListeningInput struct {
 	Authorization string `header:"Authorization"`
-	Limit         int    `query:"limit" doc:"Max items (default 10)"`
+	Limit         int    `query:"limit" default:"10" minimum:"1" maximum:"100" doc:"Max items"`
 }
 
 // ContinueListeningItemResponse represents an item in continue listening.

--- a/internal/api/playback_handlers.go
+++ b/internal/api/playback_handlers.go
@@ -245,8 +245,8 @@ func (s *Server) handleUpdateBookPreferences(ctx context.Context, input *UpdateB
 
 // PreparePlaybackRequest is the request body for preparing audio playback.
 type PreparePlaybackRequest struct {
-	BookID       string   `json:"book_id" doc:"Book ID"`
-	AudioFileID  string   `json:"audio_file_id" doc:"Audio file ID"`
+	BookID       string   `json:"book_id" validate:"required" doc:"Book ID"`
+	AudioFileID  string   `json:"audio_file_id" validate:"required" doc:"Audio file ID"`
 	Capabilities []string `json:"capabilities" doc:"Codecs the client can play (e.g., aac, mp3, opus)"`
 	Spatial      bool     `json:"spatial" doc:"Whether client prefers spatial audio"`
 }

--- a/internal/api/series_handlers.go
+++ b/internal/api/series_handlers.go
@@ -89,7 +89,7 @@ func (s *Server) registerSeriesRoutes() {
 type ListSeriesInput struct {
 	Authorization string `header:"Authorization"`
 	Cursor        string `query:"cursor" doc:"Pagination cursor"`
-	Limit         int    `query:"limit" doc:"Items per page (default 50)"`
+	Limit         int    `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Items per page"`
 }
 
 // SeriesResponse contains series data in API responses.

--- a/internal/api/social_handlers.go
+++ b/internal/api/social_handlers.go
@@ -81,7 +81,7 @@ type GetLeaderboardInput struct {
 	Authorization string `header:"Authorization"`
 	Period        string `query:"period" enum:"week,month,year,all" default:"week" doc:"Time period for leaderboard"`
 	Category      string `query:"category" enum:"time,books,streak" default:"time" doc:"Ranking category"`
-	Limit         int    `query:"limit" doc:"Max entries (default 10, max 50)"`
+	Limit         int    `query:"limit" default:"10" minimum:"1" maximum:"50" doc:"Max entries"`
 }
 
 // LeaderboardEntryResponse represents a single leaderboard entry.
@@ -567,7 +567,7 @@ func (s *Server) handleGetActivityFeed(ctx context.Context, input *GetActivityFe
 // GetCurrentlyListeningInput contains parameters for getting currently listening books.
 type GetCurrentlyListeningInput struct {
 	Authorization string `header:"Authorization"`
-	Limit         int    `query:"limit" default:"10" doc:"Max books to return (max 20)"`
+	Limit         int    `query:"limit" default:"10" minimum:"1" maximum:"50" doc:"Max books to return"`
 }
 
 // CurrentlyListeningReaderResponse represents a reader for avatar display.
@@ -606,7 +606,7 @@ type GetCurrentlyListeningOutput struct {
 // GetDiscoverBooksInput contains parameters for getting discovery books.
 type GetDiscoverBooksInput struct {
 	Authorization string `header:"Authorization"`
-	Limit         int    `query:"limit" default:"10" doc:"Max books to return (max 20)"`
+	Limit         int    `query:"limit" default:"10" minimum:"1" maximum:"50" doc:"Max books to return"`
 }
 
 // DiscoverBookResponse represents a book for discovery.

--- a/internal/api/sync_handlers.go
+++ b/internal/api/sync_handlers.go
@@ -101,7 +101,7 @@ type SyncManifestOutput struct {
 type GetSyncBooksInput struct {
 	Authorization string `header:"Authorization"`
 	Cursor        string `query:"cursor" doc:"Pagination cursor"`
-	Limit         int    `query:"limit" doc:"Items per page (default 50)"`
+	Limit         int    `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Items per page"`
 	UpdatedAfter  string `query:"updated_after" doc:"For delta sync, only return items updated after this time (RFC3339)"`
 }
 
@@ -122,7 +122,7 @@ type SyncBooksOutput struct {
 type GetSyncContributorsInput struct {
 	Authorization string `header:"Authorization"`
 	Cursor        string `query:"cursor" doc:"Pagination cursor"`
-	Limit         int    `query:"limit" doc:"Items per page (default 50)"`
+	Limit         int    `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Items per page"`
 	UpdatedAfter  string `query:"updated_after" doc:"For delta sync, only return items updated after this time (RFC3339)"`
 }
 
@@ -160,7 +160,7 @@ type SyncContributorsOutput struct {
 type GetSyncSeriesInput struct {
 	Authorization string `header:"Authorization"`
 	Cursor        string `query:"cursor" doc:"Pagination cursor"`
-	Limit         int    `query:"limit" doc:"Items per page (default 50)"`
+	Limit         int    `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Items per page"`
 	UpdatedAfter  string `query:"updated_after" doc:"For delta sync, only return items updated after this time (RFC3339)"`
 }
 


### PR DESCRIPTION
Systematic audit of all API handlers for missing/inconsistent request validation.\n\n## Changes (8 files)\n\n-  — : default 10, min 1, max 100\n-  — 3x  fields: default 50, min 1, max 500\n-  —  bounds +  required validation\n-  — : default 50, min 1, max 500\n-  —  bounds on leaderboard, currently-listening, discover\n-  —  bounds on user search\n-  —  and  marked required\n-  — returns 400 on invalid  instead of silently ignoring