### PR TITLE
⚡ Scope RecalculateSessionStatuses to book/user — fixes 7min mapping freeze

### DIFF
--- a/internal/api/admin_abs_import_handlers.go
+++ b/internal/api/admin_abs_import_handlers.go
@@ -840,7 +840,7 @@ func (s *Server) handleMapABSImportUser(ctx context.Context, input *MapABSImport
 	}
 
 	// Recalculate session statuses
-	if err := s.store.RecalculateSessionStatuses(ctx, input.ID); err != nil {
+	if err := s.store.RecalculateSessionStatusesForUser(ctx, input.ID, input.ABSUserID); err != nil {
 		s.logger.Error("failed to recalculate sessions", slog.String("error", err.Error()))
 	}
 
@@ -868,7 +868,7 @@ func (s *Server) handleClearABSImportUserMapping(ctx context.Context, input *Cle
 	}
 
 	// Recalculate session statuses
-	if err := s.store.RecalculateSessionStatuses(ctx, input.ID); err != nil {
+	if err := s.store.RecalculateSessionStatusesForUser(ctx, input.ID, input.ABSUserID); err != nil {
 		s.logger.Error("failed to recalculate sessions", slog.String("error", err.Error()))
 	}
 
@@ -938,7 +938,7 @@ func (s *Server) handleMapABSImportBook(ctx context.Context, input *MapABSImport
 	}
 
 	// Recalculate session statuses
-	if err := s.store.RecalculateSessionStatuses(ctx, input.ID); err != nil {
+	if err := s.store.RecalculateSessionStatusesForBook(ctx, input.ID, input.ABSMediaID); err != nil {
 		s.logger.Error("failed to recalculate sessions", slog.String("error", err.Error()))
 	}
 
@@ -966,7 +966,7 @@ func (s *Server) handleClearABSImportBookMapping(ctx context.Context, input *Cle
 	}
 
 	// Recalculate session statuses
-	if err := s.store.RecalculateSessionStatuses(ctx, input.ID); err != nil {
+	if err := s.store.RecalculateSessionStatusesForBook(ctx, input.ID, input.ABSMediaID); err != nil {
 		s.logger.Error("failed to recalculate sessions", slog.String("error", err.Error()))
 	}
 

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -356,6 +356,8 @@ type Store interface {
 	UpdateABSImportSessionStatus(ctx context.Context, importID, sessionID string, status domain.SessionImportStatus) error
 	SkipABSImportSession(ctx context.Context, importID, sessionID, reason string) error
 	RecalculateSessionStatuses(ctx context.Context, importID string) error
+	RecalculateSessionStatusesForBook(ctx context.Context, importID, absMediaID string) error
+	RecalculateSessionStatusesForUser(ctx context.Context, importID, absUserID string) error
 	GetABSImportStats(ctx context.Context, importID string) (mapped, unmapped, ready, imported int, err error)
 	CreateABSImportProgress(ctx context.Context, progress *domain.ABSImportProgress) error
 	GetABSImportProgress(ctx context.Context, importID, absUserID, absMediaID string) (*domain.ABSImportProgress, error)

--- a/internal/store/sqlite/abs_import.go
+++ b/internal/store/sqlite/abs_import.go
@@ -1010,3 +1010,113 @@ func (s *Store) FindABSImportProgressByListenUpBook(ctx context.Context, importI
 	}
 	return p, nil
 }
+
+// RecalculateSessionStatusesForBook recalculates session statuses for sessions
+// involving a specific book (abs_media_id). Much faster than full recalculation.
+func (s *Store) RecalculateSessionStatusesForBook(ctx context.Context, importID, absMediaID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE abs_import_sessions SET status = 'pending_book'
+		WHERE import_id = ?
+			AND abs_media_id = ?
+			AND status NOT IN ('imported', 'skipped')
+			AND abs_media_id NOT IN (
+				SELECT abs_media_id FROM abs_import_books
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)`,
+		importID, absMediaID, importID)
+	if err != nil {
+		return fmt.Errorf("update pending_book sessions: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE abs_import_sessions SET status = 'ready'
+		WHERE import_id = ?
+			AND abs_media_id = ?
+			AND status NOT IN ('imported', 'skipped')
+			AND abs_user_id IN (
+				SELECT abs_user_id FROM abs_import_users
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)
+			AND abs_media_id IN (
+				SELECT abs_media_id FROM abs_import_books
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)`,
+		importID, absMediaID, importID, importID)
+	if err != nil {
+		return fmt.Errorf("update ready sessions: %w", err)
+	}
+
+	// Handle case where book mapping was cleared - sessions with unmapped user go to pending_user
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE abs_import_sessions SET status = 'pending_user'
+		WHERE import_id = ?
+			AND abs_media_id = ?
+			AND status NOT IN ('imported', 'skipped')
+			AND abs_user_id NOT IN (
+				SELECT abs_user_id FROM abs_import_users
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)`,
+		importID, absMediaID, importID)
+	if err != nil {
+		return fmt.Errorf("update pending_user sessions: %w", err)
+	}
+
+	return nil
+}
+
+// RecalculateSessionStatusesForUser recalculates session statuses for sessions
+// involving a specific user (abs_user_id). Much faster than full recalculation.
+func (s *Store) RecalculateSessionStatusesForUser(ctx context.Context, importID, absUserID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE abs_import_sessions SET status = 'pending_user'
+		WHERE import_id = ?
+			AND abs_user_id = ?
+			AND status NOT IN ('imported', 'skipped')
+			AND abs_user_id NOT IN (
+				SELECT abs_user_id FROM abs_import_users
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)`,
+		importID, absUserID, importID)
+	if err != nil {
+		return fmt.Errorf("update pending_user sessions: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE abs_import_sessions SET status = 'ready'
+		WHERE import_id = ?
+			AND abs_user_id = ?
+			AND status NOT IN ('imported', 'skipped')
+			AND abs_user_id IN (
+				SELECT abs_user_id FROM abs_import_users
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)
+			AND abs_media_id IN (
+				SELECT abs_media_id FROM abs_import_books
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)`,
+		importID, absUserID, importID, importID)
+	if err != nil {
+		return fmt.Errorf("update ready sessions: %w", err)
+	}
+
+	// Handle case where user mapping was cleared - sessions with unmapped book go to pending_book
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE abs_import_sessions SET status = 'pending_book'
+		WHERE import_id = ?
+			AND abs_user_id = ?
+			AND status NOT IN ('imported', 'skipped')
+			AND abs_user_id IN (
+				SELECT abs_user_id FROM abs_import_users
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)
+			AND abs_media_id NOT IN (
+				SELECT abs_media_id FROM abs_import_books
+				WHERE import_id = ? AND listenup_id IS NOT NULL
+			)`,
+		importID, absUserID, importID, importID)
+	if err != nil {
+		return fmt.Errorf("update pending_book sessions: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #41

Adds RecalculateSessionStatusesForBook and RecalculateSessionStatusesForUser so mapping operations only recalculate sessions for the specific book/user being mapped — O(1-10 sessions) instead of O(all sessions).

Import creation recalculation remains full-scope but now runs in a background goroutine, returning the import ID immediately.