### PR TITLE
🐛 Fix missing quotes on role literal in ListAllBookContributorNames SQL

### DIFF
--- a/internal/store/sqlite/book_contributors.go
+++ b/internal/store/sqlite/book_contributors.go
@@ -204,7 +204,7 @@ func (s *Store) ListAllBookContributorNames(ctx context.Context) (map[string][]s
 		FROM book_contributors bc
 		JOIN contributors c ON c.id = bc.contributor_id,
 		     json_each(bc.roles) je
-		WHERE je.value = author AND c.deleted_at IS NULL
+		WHERE je.value = 'author' AND c.deleted_at IS NULL
 	`)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The SQL query in `ListAllBookContributorNames` was filtering with `WHERE je.value = author` — SQLite treated `author` as a column reference rather than a string literal, causing a runtime error. The query failed silently (logged a WARN), returning an empty map, so `PreloadBooks` populated `CachedBook.Authors` as nil for every book. Fuzzy matching was therefore still broken despite the v0.6.6 batch-load fix.

Fix: add single quotes → `WHERE je.value = author`.

Fixes ABS import fuzzy match rate (was stuck at 245/1011 = 24%).