### PR TITLE
🔍 Fix stale search index: wire auto-indexing on book writes + admin reindex endpoint

### DIFF
--- a/internal/api/search_handlers.go
+++ b/internal/api/search_handlers.go
@@ -19,6 +19,16 @@ func (s *Server) registerSearchRoutes() {
 		Tags:        []string{"Search"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleSearch)
+
+	huma.Register(s.api, huma.Operation{
+		OperationID: "admin-reindex-search",
+		Method:      http.MethodPost,
+		Path:        "/api/v1/admin/search/reindex",
+		Summary:     "Rebuild search index",
+		Description: "Triggers a full rebuild of the search index. Runs asynchronously.",
+		Tags:        []string{"Admin"},
+		Security:    []map[string][]string{{"bearer": {}}},
+	}, s.handleReindexSearch)
 }
 
 // === DTOs ===
@@ -186,4 +196,41 @@ func (s *Server) handleSearch(ctx context.Context, input *SearchInput) (*SearchO
 	resp.Total = int64(len(resp.Hits))
 
 	return &SearchOutput{Body: resp}, nil
+}
+
+func (s *Server) handleReindexSearch(ctx context.Context, _ *struct{}) (*struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}, error) {
+	userID, err := GetUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := s.store.GetUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !user.IsAdmin() {
+		return nil, huma.Error403Forbidden("admin access required")
+	}
+
+	go func() {
+		reindexCtx := context.Background()
+		if err := s.services.Search.ReindexAll(reindexCtx); err != nil {
+			s.logger.Error("reindex failed", "error", err)
+		} else {
+			count, _ := s.services.Search.DocumentCount()
+			s.logger.Info("reindex completed", "documents", count)
+		}
+	}()
+
+	resp := &struct {
+		Body struct {
+			Message string `json:"message"`
+		}
+	}{}
+	resp.Body.Message = "Reindex started"
+	return resp, nil
 }

--- a/internal/store/sqlite/books.go
+++ b/internal/store/sqlite/books.go
@@ -281,6 +281,25 @@ func coverArgs(img *domain.ImageFileInfo) (coverPath, coverFilename, coverFormat
 
 // CreateBook inserts a book row along with its audio files and chapters in a transaction.
 // Returns store.ErrAlreadyExists on duplicate ID or path.
+// indexBookAsync triggers a non-blocking search index update for a book.
+// Errors are logged but do not fail the caller.
+func (s *Store) indexBookAsync(ctx context.Context, book *domain.Book) {
+	go func() {
+		if err := s.searchIndexer.IndexBook(ctx, book); err != nil {
+			s.logger.Warn("failed to index book", "book_id", book.ID, "error", err)
+		}
+	}()
+}
+
+// deleteBookFromIndexAsync triggers a non-blocking search index removal.
+func (s *Store) deleteBookFromIndexAsync(ctx context.Context, id string) {
+	go func() {
+		if err := s.searchIndexer.DeleteBook(ctx, id); err != nil {
+			s.logger.Warn("failed to delete book from index", "book_id", id, "error", err)
+		}
+	}()
+}
+
 func (s *Store) CreateBook(ctx context.Context, book *domain.Book) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -292,7 +311,11 @@ func (s *Store) CreateBook(ctx context.Context, book *domain.Book) error {
 		return err
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.indexBookAsync(ctx, book)
+	return nil
 }
 
 // createBookTx inserts a book and its audio files/chapters using the provided transaction.
@@ -617,7 +640,11 @@ func (s *Store) UpdateBook(ctx context.Context, book *domain.Book) error {
 		}
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.indexBookAsync(ctx, book)
+	return nil
 }
 
 // DeleteBook performs a soft delete by setting deleted_at and updated_at.
@@ -640,6 +667,7 @@ func (s *Store) DeleteBook(ctx context.Context, id string) error {
 	if n == 0 {
 		return store.ErrNotFound
 	}
+	s.deleteBookFromIndexAsync(ctx, id)
 	return nil
 }
 


### PR DESCRIPTION
The SQLite migration (167d0e3) dropped the `searchIndexer.IndexBook()` calls that existed in the old store. The field was preserved on the struct but nothing ever called it — so any book created or updated after Feb 21 was silently not indexed.

**Changes:**

`internal/store/sqlite/books.go`
- Add `indexBookAsync(ctx, book)` helper — fire-and-forget goroutine, logs errors but does not fail the caller
- Add `deleteBookFromIndexAsync(ctx, id)` helper — same pattern
- Wire both into `CreateBook`, `UpdateBook`, and `DeleteBook`

`internal/api/search_handlers.go`
- Add `POST /api/v1/admin/search/reindex` endpoint (admin only) that triggers a full `ReindexAll` asynchronously — needed to repair the stale index on existing deployments

After deploying, call `POST /api/v1/admin/search/reindex` once to rebuild the index from current DB state.