### PR TITLE
🐛 Resolve server name from instance settings in invite details

### DIFF
--- a/internal/service/invite.go
+++ b/internal/service/invite.go
@@ -166,7 +166,11 @@ func (s *InviteService) GetInviteDetails(ctx context.Context, code string) (*Inv
 	}
 
 	// Get server name (from instance settings)
-	serverName := "ListenUp Server" // TODO: Get from instance settings
+	serverName := "ListenUp Server" // fallback
+	instance, instanceErr := s.store.GetInstance(ctx)
+	if instanceErr == nil && instance.Name != "" {
+		serverName = instance.Name
+	}
 
 	return &InviteDetailsResponse{
 		Name:       invite.Name,


### PR DESCRIPTION
Fixes #71

`GetInviteDetails` was returning a hardcoded "ListenUp Server" name. Now reads the instance name from the database, falling back to the default if unavailable.