### PR TITLE
🔒 Invalidate user sessions on admin actions

### DIFF
--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -182,7 +182,16 @@ func (s *AdminService) DeleteUser(ctx context.Context, adminUserID, targetUserID
 		}
 	}
 
-	// TODO: Invalidate all user sessions
+	// Invalidate all user sessions so the deleted user cannot continue using stale tokens
+	if err := s.store.DeleteAllUserSessions(ctx, targetUserID); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("Failed to invalidate sessions for deleted user",
+				"user_id", targetUserID,
+				"error", err,
+			)
+		}
+		// Non-fatal: user is already deleted and will fail auth on next token refresh
+	}
 
 	if s.logger != nil {
 		s.logger.Info("User deleted by admin",


### PR DESCRIPTION
Fixes #69

When an admin deletes a user, their existing sessions were not being terminated — the TODO at line 185 of admin.go was never implemented. Users could retain access via stale refresh tokens until they naturally expired.

This calls `DeleteAllUserSessions` (already exists in the store layer) after soft-deleting the user, ensuring all sessions are immediately revoked. The call is non-fatal: if it fails, the user is already soft-deleted and will fail auth on next token refresh anyway.