### PR TITLE
🐛 Handle malformed double-Z timestamps in parseTime

### DIFF
--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -115,7 +116,17 @@ func formatTime(t time.Time) string {
 
 // parseTime parses a RFC3339Nano string back to time.Time.
 func parseTime(s string) (time.Time, error) {
-	return time.Parse(time.RFC3339Nano, s)
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		// Attempt to salvage malformed timestamps (e.g. double "ZZ" suffix
+		// from earlier ABS import bugs) before giving up.
+		cleaned := strings.TrimRight(s, "Z") + "Z"
+		t, err2 := time.Parse(time.RFC3339Nano, cleaned)
+		if err2 == nil {
+			return t, nil
+		}
+	}
+	return t, err
 }
 
 // parseNullableTime parses an optional time string.


### PR DESCRIPTION
## Problem
`GET /api/v1/listening/progress` returns 500 for all users. The `scanPlaybackState` function calls `parseTime()` which fails on malformed timestamps with double-Z suffixes (e.g. `2025-06-04T10:30:47.66ZZ`).

42 records in `playback_state` had this corruption, likely from an earlier version of the ABS import code. One bad record causes the entire query to fail, so `isFinished` state never syncs to clients — resulting in all completed books appearing in Continue Listening.

## Fix
Added a fallback in `parseTime()`: if the initial `time.Parse` fails, strip duplicate trailing Z characters and retry. This makes the query resilient to malformed timestamps without silently accepting truly invalid data.

## Data Fix (already applied)
Ran on Rupert's production DB:
```sql
UPDATE playback_state SET last_played_at = REPLACE(last_played_at, 'ZZ', 'Z') WHERE last_played_at LIKE '%ZZ';
-- (same for started_at, finished_at, updated_at)
```
42 records corrected. Endpoint verified working after cleanup.