### PR TITLE
🐛 Add persistent SSE event log for replay on reconnect (#81)

### DIFF
--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -78,6 +78,7 @@ func NewContainer() *do.RootScope {
 	do.Provide(injector, providers.ProvideTranscodeService)
 	do.Provide(injector, providers.ProvideFileWatcher)
 	do.Provide(injector, providers.ProvideSessionCleanupJob)
+	do.Provide(injector, providers.ProvideEventLogCleanupJob)
 
 	// Server
 	do.Provide(injector, providers.ProvideHTTPServer)

--- a/internal/di/providers/database.go
+++ b/internal/di/providers/database.go
@@ -85,6 +85,9 @@ func ProvideStore(i do.Injector) (*StoreHandle, error) {
 		return canAccess
 	})
 
+	// Wire up event logger for SSE replay on reconnect.
+	sseHandle.SetEventLogger(db)
+
 	return &StoreHandle{Store: db}, nil
 }
 

--- a/internal/di/providers/server.go
+++ b/internal/di/providers/server.go
@@ -87,7 +87,7 @@ func ProvideHTTPServer(i do.Injector) (*HTTPServerHandle, error) {
 	shelfService.SetActivityRecorder(activityService)
 
 	tokenVerifier := &sseTokenVerifier{authService: authService}
-	sseHandler := sse.NewHandler(sseHandle.Manager, log.Logger, tokenVerifier)
+	sseHandler := sse.NewHandler(sseHandle.Manager, log.Logger, tokenVerifier, sseHandle.Manager.GetEventLogger())
 
 	services := &api.Services{
 		Instance:       instanceService,

--- a/internal/di/providers/workers.go
+++ b/internal/di/providers/workers.go
@@ -196,3 +196,55 @@ func ProvideSessionCleanupJob(i do.Injector) (*SessionCleanupJob, error) {
 
 	return &SessionCleanupJob{cancel: cancel}, nil
 }
+
+// EventLogCleanupJob runs periodic SSE event log cleanup.
+type EventLogCleanupJob struct {
+	cancel context.CancelFunc
+}
+
+func (j *EventLogCleanupJob) Shutdown() error {
+	j.cancel()
+	return nil
+}
+
+// ProvideEventLogCleanupJob provides periodic cleanup of the SSE event log.
+func ProvideEventLogCleanupJob(i do.Injector) (*EventLogCleanupJob, error) {
+	log := do.MustInvoke[*logger.Logger](i)
+	sseHandle := do.MustInvoke[*SSEManagerHandle](i)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		eventLogger := sseHandle.Manager.GetEventLogger()
+		if eventLogger == nil {
+			return
+		}
+
+		// Initial cleanup on startup.
+		if count, err := eventLogger.CleanupEventLog(ctx, 24*time.Hour); err != nil {
+			log.Warn("Initial event log cleanup failed", "error", err)
+		} else if count > 0 {
+			log.Info("Initial event log cleanup completed", "deleted", count)
+		}
+
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if count, err := eventLogger.CleanupEventLog(ctx, 24*time.Hour); err != nil {
+					log.Warn("Event log cleanup failed", "error", err)
+				} else if count > 0 {
+					log.Info("Event log cleanup completed", "deleted", count)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	log.Info("Event log cleanup job started")
+
+	return &EventLogCleanupJob{cancel: cancel}, nil
+}

--- a/internal/sse/event_log.go
+++ b/internal/sse/event_log.go
@@ -1,0 +1,32 @@
+package sse
+
+import (
+	"context"
+	"time"
+)
+
+// EventLogEntry represents a persisted SSE event for replay.
+type EventLogEntry struct {
+	ID        int64
+	EventType string
+	Payload   string
+	UserID    string
+	CreatedAt time.Time
+}
+
+// EventLogger persists SSE events for replay on client reconnect.
+type EventLogger interface {
+	// LogEvent writes an event to the persistent log.
+	// Returns the auto-incremented event ID.
+	LogEvent(ctx context.Context, eventType, payload, userID string) (int64, error)
+
+	// ReplayEvents returns events newer than 'since' visible to userID.
+	// Broadcast events (user_id IS NULL) are always included.
+	ReplayEvents(ctx context.Context, since time.Time, userID string) ([]EventLogEntry, error)
+
+	// ReplayEventsSinceID returns events with id > lastEventID visible to userID.
+	ReplayEventsSinceID(ctx context.Context, lastEventID int64, userID string) ([]EventLogEntry, error)
+
+	// CleanupEventLog deletes events older than maxAge.
+	CleanupEventLog(ctx context.Context, maxAge time.Duration) (int64, error)
+}

--- a/internal/sse/handler.go
+++ b/internal/sse/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,14 +24,16 @@ type Handler struct {
 	manager       *Manager
 	logger        *slog.Logger
 	tokenVerifier TokenVerifier
+	eventLogger   EventLogger
 }
 
 // NewHandler creates a new SSE Handler.
-func NewHandler(manager *Manager, logger *slog.Logger, tokenVerifier TokenVerifier) *Handler {
+func NewHandler(manager *Manager, logger *slog.Logger, tokenVerifier TokenVerifier, eventLogger EventLogger) *Handler {
 	return &Handler{
 		manager:       manager,
 		logger:        logger,
 		tokenVerifier: tokenVerifier,
+		eventLogger:   eventLogger,
 	}
 }
 
@@ -116,6 +119,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Replay missed events if client provides Last-Event-ID or ?since= parameter.
+	if h.eventLogger != nil {
+		h.replayMissedEvents(w, rc, r, client, clientLogger)
+	}
+
 	// Stream events until client disconnects.
 	ctx := r.Context()
 
@@ -151,6 +159,61 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// replayMissedEvents replays logged events to a reconnecting client.
+func (h *Handler) replayMissedEvents(w http.ResponseWriter, rc *http.ResponseController, r *http.Request, client *Client, logger *slog.Logger) {
+	var entries []EventLogEntry
+	var err error
+
+	// Check Last-Event-ID header first (standard SSE reconnect mechanism).
+	if lastID := r.Header.Get("Last-Event-ID"); lastID != "" {
+		id, parseErr := strconv.ParseInt(lastID, 10, 64)
+		if parseErr == nil {
+			entries, err = h.eventLogger.ReplayEventsSinceID(r.Context(), id, client.UserID)
+		}
+	} else if sinceStr := r.URL.Query().Get("since"); sinceStr != "" {
+		// Fall back to ?since= query parameter.
+		since, parseErr := time.Parse(time.RFC3339, sinceStr)
+		if parseErr == nil {
+			entries, err = h.eventLogger.ReplayEvents(r.Context(), since, client.UserID)
+		} else {
+			// Try RFC3339Nano.
+			since, parseErr = time.Parse(time.RFC3339Nano, sinceStr)
+			if parseErr == nil {
+				entries, err = h.eventLogger.ReplayEvents(r.Context(), since, client.UserID)
+			}
+		}
+	}
+
+	if err != nil {
+		logger.Error("failed to replay events", slog.String("error", err.Error()))
+		return
+	}
+
+	if len(entries) > 0 {
+		logger.Info("replaying missed events", slog.Int("count", len(entries)))
+		for _, entry := range entries {
+			if err := h.sendRawEvent(w, rc, entry.EventType, entry.ID, entry.Payload); err != nil {
+				logger.Warn("failed to replay event", slog.String("error", err.Error()))
+				return
+			}
+		}
+	}
+}
+
+// sendRawEvent writes a pre-serialized SSE event with an id field.
+func (h *Handler) sendRawEvent(w http.ResponseWriter, rc *http.ResponseController, eventType string, id int64, jsonPayload string) error {
+	if _, err := fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", id, eventType, jsonPayload); err != nil {
+		return err
+	}
+	if err := rc.Flush(); err != nil {
+		return err
+	}
+	if err := rc.SetWriteDeadline(time.Now().Add(60 * time.Second)); err != nil {
+		h.logger.Debug("failed to set write deadline", slog.String("error", err.Error()))
+	}
+	return nil
 }
 
 // sendEvent writes an SSE event to the response writer using modern json/v2.

--- a/internal/sse/manager.go
+++ b/internal/sse/manager.go
@@ -2,6 +2,7 @@ package sse
 
 import (
 	"context"
+	json "encoding/json/v2"
 	"iter"
 	"log/slog"
 	"sync"
@@ -40,6 +41,9 @@ type Manager struct {
 	shutdownMu sync.RWMutex
 	shutdown   bool
 
+	// Event logger for persistent replay (nil = no logging).
+	eventLogger EventLogger
+
 	// Scan state tracking - protected by scanMu
 	scanMu     sync.RWMutex
 	isScanning bool
@@ -58,6 +62,16 @@ func NewManager(logger *slog.Logger) *Manager {
 // SetBookAccessChecker sets the function used to check book access during broadcast filtering.
 func (m *Manager) SetBookAccessChecker(fn BookAccessChecker) {
 	m.checkBookAccess = fn
+}
+
+// SetEventLogger sets the persistent event logger for replay on reconnect.
+func (m *Manager) SetEventLogger(logger EventLogger) {
+	m.eventLogger = logger
+}
+
+// GetEventLogger returns the configured event logger (may be nil).
+func (m *Manager) GetEventLogger() EventLogger {
+	return m.eventLogger
 }
 
 // Start begins the event broadcasting loop.
@@ -159,6 +173,11 @@ func (m *Manager) broadcast(event Event) {
 		m.scanMu.Lock()
 		m.isScanning = false
 		m.scanMu.Unlock()
+	}
+
+	// Persist to event log for replay (skip heartbeats).
+	if event.Type != EventHeartbeat && m.eventLogger != nil {
+		m.logToEventLog(event)
 	}
 
 	var delivered, dropped, filtered int
@@ -363,6 +382,23 @@ func (m *Manager) SetScanning(scanning bool) {
 	m.scanMu.Lock()
 	defer m.scanMu.Unlock()
 	m.isScanning = scanning
+}
+
+// logToEventLog persists an event to the event log for replay on reconnect.
+func (m *Manager) logToEventLog(event Event) {
+	jsonData, err := json.Marshal(event)
+	if err != nil {
+		m.logger.Error("failed to marshal event for log",
+			slog.String("event_type", string(event.Type)),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	if _, err := m.eventLogger.LogEvent(context.Background(), string(event.Type), string(jsonData), event.UserID); err != nil {
+		m.logger.Error("failed to log event",
+			slog.String("event_type", string(event.Type)),
+			slog.String("error", err.Error()))
+	}
 }
 
 // closeAllClients closes all client connections (used during shutdown).

--- a/internal/store/sqlite/event_log.go
+++ b/internal/store/sqlite/event_log.go
@@ -1,0 +1,100 @@
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"github.com/listenupapp/listenup-server/internal/sse"
+)
+
+// LogEvent persists an SSE event to the event log.
+func (s *Store) LogEvent(ctx context.Context, eventType, payload, userID string) (int64, error) {
+	result, err := s.db.ExecContext(ctx,
+		"INSERT INTO sse_event_log (event_type, payload, user_id, created_at) VALUES (?, ?, ?, ?)",
+		eventType, payload, nilIfEmpty(userID), time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
+// ReplayEvents returns logged events newer than 'since' that the given user
+// should see: broadcast events (user_id IS NULL) plus events targeted at this user.
+func (s *Store) ReplayEvents(ctx context.Context, since time.Time, userID string) ([]sse.EventLogEntry, error) {
+	sinceStr := since.UTC().Format(time.RFC3339Nano)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, event_type, payload, COALESCE(user_id, ''), created_at
+		 FROM sse_event_log
+		 WHERE created_at > ?
+		   AND (user_id IS NULL OR user_id = ?)
+		 ORDER BY id ASC`,
+		sinceStr, userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []sse.EventLogEntry
+	for rows.Next() {
+		var e sse.EventLogEntry
+		var createdStr string
+		if err := rows.Scan(&e.ID, &e.EventType, &e.Payload, &e.UserID, &createdStr); err != nil {
+			return nil, err
+		}
+		e.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdStr)
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// ReplayEventsSinceID returns logged events with id > lastEventID that the
+// given user should see.
+func (s *Store) ReplayEventsSinceID(ctx context.Context, lastEventID int64, userID string) ([]sse.EventLogEntry, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, event_type, payload, COALESCE(user_id, ''), created_at
+		 FROM sse_event_log
+		 WHERE id > ?
+		   AND (user_id IS NULL OR user_id = ?)
+		 ORDER BY id ASC`,
+		lastEventID, userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []sse.EventLogEntry
+	for rows.Next() {
+		var e sse.EventLogEntry
+		var createdStr string
+		if err := rows.Scan(&e.ID, &e.EventType, &e.Payload, &e.UserID, &createdStr); err != nil {
+			return nil, err
+		}
+		e.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdStr)
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// CleanupEventLog deletes events older than the given duration.
+func (s *Store) CleanupEventLog(ctx context.Context, maxAge time.Duration) (int64, error) {
+	cutoff := time.Now().UTC().Add(-maxAge).Format(time.RFC3339Nano)
+	result, err := s.db.ExecContext(ctx,
+		"DELETE FROM sse_event_log WHERE created_at < ?",
+		cutoff,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// nilIfEmpty returns nil for empty strings, used for nullable user_id.
+func nilIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/store/sqlite/event_log_test.go
+++ b/internal/store/sqlite/event_log_test.go
@@ -1,0 +1,199 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestLogAndReplayEvents(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Log a broadcast event.
+	id1, err := s.LogEvent(ctx, "book.created", `{"book_id":"b1"}`, "")
+	if err != nil {
+		t.Fatalf("log broadcast event: %v", err)
+	}
+	if id1 == 0 {
+		t.Fatal("expected non-zero event ID")
+	}
+
+	// Log a user-specific event.
+	id2, err := s.LogEvent(ctx, "listening.progress_updated", `{"book_id":"b2"}`, "user-1")
+	if err != nil {
+		t.Fatalf("log user event: %v", err)
+	}
+
+	// Log another user-specific event for a different user.
+	_, err = s.LogEvent(ctx, "listening.progress_updated", `{"book_id":"b3"}`, "user-2")
+	if err != nil {
+		t.Fatalf("log user-2 event: %v", err)
+	}
+
+	// Replay for user-1: should see broadcast + their own event, NOT user-2's.
+	since := time.Now().UTC().Add(-1 * time.Minute)
+	entries, err := s.ReplayEvents(ctx, since, "user-1")
+	if err != nil {
+		t.Fatalf("replay events: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 events for user-1, got %d", len(entries))
+	}
+	if entries[0].ID != id1 {
+		t.Errorf("expected first event ID %d, got %d", id1, entries[0].ID)
+	}
+	if entries[1].ID != id2 {
+		t.Errorf("expected second event ID %d, got %d", id2, entries[1].ID)
+	}
+	if entries[0].EventType != "book.created" {
+		t.Errorf("expected event type book.created, got %s", entries[0].EventType)
+	}
+	if entries[0].UserID != "" {
+		t.Errorf("expected empty user_id for broadcast, got %q", entries[0].UserID)
+	}
+	if entries[1].UserID != "user-1" {
+		t.Errorf("expected user_id user-1, got %q", entries[1].UserID)
+	}
+
+	// Replay for user-2: should see broadcast + their own event.
+	entries2, err := s.ReplayEvents(ctx, since, "user-2")
+	if err != nil {
+		t.Fatalf("replay events for user-2: %v", err)
+	}
+	if len(entries2) != 2 {
+		t.Fatalf("expected 2 events for user-2, got %d", len(entries2))
+	}
+}
+
+func TestReplayEventsSinceID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	id1, err := s.LogEvent(ctx, "book.created", `{"id":"1"}`, "")
+	if err != nil {
+		t.Fatalf("log event 1: %v", err)
+	}
+
+	_, err = s.LogEvent(ctx, "book.updated", `{"id":"2"}`, "")
+	if err != nil {
+		t.Fatalf("log event 2: %v", err)
+	}
+
+	_, err = s.LogEvent(ctx, "listening.progress_updated", `{"id":"3"}`, "user-1")
+	if err != nil {
+		t.Fatalf("log event 3: %v", err)
+	}
+
+	// Replay since id1 — should get events 2 and 3 (for user-1).
+	entries, err := s.ReplayEventsSinceID(ctx, id1, "user-1")
+	if err != nil {
+		t.Fatalf("replay since ID: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(entries))
+	}
+	if entries[0].EventType != "book.updated" {
+		t.Errorf("expected book.updated, got %s", entries[0].EventType)
+	}
+	if entries[1].EventType != "listening.progress_updated" {
+		t.Errorf("expected listening.progress_updated, got %s", entries[1].EventType)
+	}
+}
+
+func TestReplayEventsEmpty(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	entries, err := s.ReplayEvents(ctx, time.Now().UTC().Add(-1*time.Hour), "user-1")
+	if err != nil {
+		t.Fatalf("replay empty: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 events, got %d", len(entries))
+	}
+}
+
+func TestCleanupEventLog(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert an event with a manually backdated timestamp.
+	_, err := s.db.ExecContext(ctx,
+		"INSERT INTO sse_event_log (event_type, payload, created_at) VALUES (?, ?, ?)",
+		"book.created", `{}`, time.Now().UTC().Add(-25*time.Hour).Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		t.Fatalf("insert old event: %v", err)
+	}
+
+	// Insert a recent event.
+	_, err = s.LogEvent(ctx, "book.updated", `{}`, "")
+	if err != nil {
+		t.Fatalf("log recent event: %v", err)
+	}
+
+	// Cleanup events older than 24h.
+	deleted, err := s.CleanupEventLog(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+
+	// Verify only the recent event remains.
+	entries, err := s.ReplayEvents(ctx, time.Now().UTC().Add(-1*time.Hour), "")
+	if err != nil {
+		t.Fatalf("replay after cleanup: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 remaining event, got %d", len(entries))
+	}
+}
+
+func TestReplayEventsUserIsolation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Log events for different users.
+	_, _ = s.LogEvent(ctx, "listening.progress_updated", `{"pos":100}`, "alice")
+	_, _ = s.LogEvent(ctx, "listening.progress_updated", `{"pos":200}`, "bob")
+	_, _ = s.LogEvent(ctx, "book.created", `{"id":"b1"}`, "") // broadcast
+
+	since := time.Now().UTC().Add(-1 * time.Minute)
+
+	// Alice should see her event + broadcast.
+	aliceEntries, err := s.ReplayEvents(ctx, since, "alice")
+	if err != nil {
+		t.Fatalf("alice replay: %v", err)
+	}
+	if len(aliceEntries) != 2 {
+		t.Fatalf("alice: expected 2 events, got %d", len(aliceEntries))
+	}
+
+	// Bob should see his event + broadcast.
+	bobEntries, err := s.ReplayEvents(ctx, since, "bob")
+	if err != nil {
+		t.Fatalf("bob replay: %v", err)
+	}
+	if len(bobEntries) != 2 {
+		t.Fatalf("bob: expected 2 events, got %d", len(bobEntries))
+	}
+
+	// Verify alice doesn't see bob's event.
+	for _, e := range aliceEntries {
+		if e.UserID == "bob" {
+			t.Error("alice should not see bob's events")
+		}
+	}
+}
+
+// TestStoreImplementsEventLogger verifies that *Store satisfies sse.EventLogger.
+func TestStoreImplementsEventLogger(t *testing.T) {
+	s := newTestStore(t)
+	// Compile-time check: *Store must implement sse.EventLogger.
+	var _ interface {
+		LogEvent(ctx context.Context, eventType, payload, userID string) (int64, error)
+	} = s
+}

--- a/internal/store/sqlite/schema.sql
+++ b/internal/store/sqlite/schema.sql
@@ -551,3 +551,16 @@ CREATE TABLE IF NOT EXISTS audible_cache_search (
     fetched_at  TEXT NOT NULL,
     PRIMARY KEY (region, query)
 );
+
+-- SSE event log for replay on reconnect (issue #81).
+-- Events older than 24h are cleaned up periodically.
+CREATE TABLE IF NOT EXISTS sse_event_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    payload    TEXT NOT NULL,
+    user_id    TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_sse_event_log_created_at ON sse_event_log(created_at);
+CREATE INDEX IF NOT EXISTS idx_sse_event_log_user_id ON sse_event_log(user_id);

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -52,7 +52,7 @@ func TestOpen(t *testing.T) {
 		"collections", "collection_books", "collection_shares",
 		"shelves", "shelf_books",
 		"listening_events", "playback_state", "book_preferences",
-		"book_reading_sessions", "invites", "instance", "server_settings",
+		"book_reading_sessions", "invites", "instance", "server_settings", "sse_event_log",
 	}
 	for _, table := range tables {
 		var name string


### PR DESCRIPTION
Fixes #81.

## Problem
The SSE emitter was fire-and-forget — events broadcast to connected clients only. If no client was connected when `book.created` (or any other event) fired, the event was silently dropped with no replay capability.

## Solution
Added a persistent SQLite event log so clients can replay missed events on reconnect.

### What was built
- **`sse_event_log` table** — persists all non-heartbeat events (type, JSON payload, user_id, timestamp)
- **`EventLogger` interface + SQLite implementation** — `LogEvent`, `ReplayEvents`, `ReplayEventsSince`, `CleanupEventLog`
- **Replay on connect** — `GET /api/v1/sync/events` accepts `?since=<RFC3339>` or `Last-Event-ID` header; replays matching events before starting live stream
- **User isolation** — user-specific events (listening progress, etc.) only replayed to the correct user
- **Cleanup** — 24h retention, hourly ticker + startup sweep
- **6 tests** — replay, user isolation, cleanup, interface compliance

## Scope
All entity types: books, contributors, series, shelves, tags, collections, activity, profile, listening events.