### PR TITLE
🐛 Write contributor/series/genre junction tables for scanner-created books (#85)

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -418,13 +418,9 @@ func (s *Scanner) saveToDatabase(ctx context.Context, items []*LibraryItemData, 
 	}
 
 	batchWriter := s.store.NewBatchWriter(100)
-	defer func() {
-		if err := batchWriter.Flush(ctx); err != nil {
-			s.logger.Error("failed to flush final batch", "error", err)
-		}
-	}()
 
 	var errs []error
+	var pendingBooks []*domain.Book // Books to process after flush
 
 	for _, item := range items {
 		// Check context cancellation.
@@ -502,7 +498,7 @@ func (s *Scanner) saveToDatabase(ctx context.Context, items []*LibraryItemData, 
 			}
 		}
 
-		// Save to database.
+		// Queue book for batch insert.
 		if err := batchWriter.CreateBook(ctx, book); err != nil {
 			createErr := fmt.Errorf("save %s (%s): %w", book.Title, book.Path, err)
 			errs = append(errs, createErr)
@@ -517,10 +513,20 @@ func (s *Scanner) saveToDatabase(ctx context.Context, items []*LibraryItemData, 
 		}
 
 		result.Added++
+		pendingBooks = append(pendingBooks, book)
+	}
 
+	// Flush all books to database — this is where rows are actually written.
+	if err := batchWriter.Flush(ctx); err != nil {
+		s.logger.Error("failed to flush batch", "error", err)
+		return fmt.Errorf("flush batch: %w", err)
+	}
+
+	// Post-flush operations: inbox, transcodes, SSE events.
+	// These require the book rows to exist in the database.
+	for _, book := range pendingBooks {
 		// Add to inbox if workflow is enabled
 		if inboxEnabled && inboxCollection != nil {
-			// Add book to inbox collection using the admin method
 			if err := s.store.AdminAddBookToCollection(ctx, book.ID, inboxCollection.ID); err != nil {
 				s.logger.Warn("failed to add book to inbox",
 					"book_id", book.ID,

--- a/internal/store/sqlite/batch.go
+++ b/internal/store/sqlite/batch.go
@@ -67,7 +67,13 @@ func (bw *sqliteBatchWriter) Flush(ctx context.Context) error {
 		if err := createBookTx(ctx, tx, book); err != nil {
 			tx.Rollback()
 			if errors.Is(err, store.ErrAlreadyExists) {
-				// Book already in DB — skip it and continue with the rest.
+				// Book already in DB — update its junction tables in case they're
+				// missing (e.g., book was created before junction table writing was added).
+				if err := bw.store.updateBookJunctionTables(ctx, book); err != nil {
+					// Log but don't fail — the book row already exists, junction update is best-effort.
+					continue
+				}
+				written = append(written, book)
 				continue
 			}
 			return fmt.Errorf("batch create book %s: %w", book.ID, err)

--- a/internal/store/sqlite/batch_junctions_test.go
+++ b/internal/store/sqlite/batch_junctions_test.go
@@ -1,0 +1,217 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/listenupapp/listenup-server/internal/domain"
+)
+
+func TestBatchWriter_FlushWritesJunctionTables(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Create a contributor and series first (like ConvertToBook does via extractContributors/extractSeries).
+	contributor, err := s.GetOrCreateContributor(ctx, "J.R.R. Tolkien")
+	if err != nil {
+		t.Fatalf("GetOrCreateContributor: %v", err)
+	}
+
+	series, err := s.GetOrCreateSeries(ctx, "Middle-earth")
+	if err != nil {
+		t.Fatalf("GetOrCreateSeries: %v", err)
+	}
+
+	// Create a genre (like the genre seed does).
+	now := time.Now()
+	genre := &domain.Genre{
+		Syncable: domain.Syncable{
+			ID:        "genre-fantasy",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		Name:     "Fantasy",
+		Slug:     "fantasy",
+		Path:     "/fantasy",
+		IsSystem: true,
+	}
+	if err := s.CreateGenre(ctx, genre); err != nil {
+		t.Fatalf("CreateGenre: %v", err)
+	}
+
+	// Create a book with contributors, series, and genres — exactly like scanner does.
+	book := makeTestBook("batch-junc-1", "The Hobbit", "/books/hobbit")
+	book.Contributors = []domain.BookContributor{
+		{
+			ContributorID: contributor.ID,
+			Roles:         []domain.ContributorRole{domain.RoleAuthor},
+		},
+	}
+	book.Series = []domain.BookSeries{
+		{
+			SeriesID: series.ID,
+			Sequence: "1",
+		},
+	}
+	book.GenreIDs = []string{"genre-fantasy"}
+
+	// Use BatchWriter exactly like the scanner does.
+	bw := s.NewBatchWriter(100)
+	if err := bw.CreateBook(ctx, book); err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	if err := bw.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Verify book was created.
+	got, err := s.GetBook(ctx, "batch-junc-1", "")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if got.Title != "The Hobbit" {
+		t.Errorf("book title: got %q, want %q", got.Title, "The Hobbit")
+	}
+
+	// Verify contributor junction table was written.
+	contribs, err := s.GetBookContributors(ctx, "batch-junc-1")
+	if err != nil {
+		t.Fatalf("GetBookContributors: %v", err)
+	}
+	if len(contribs) != 1 {
+		t.Errorf("expected 1 contributor, got %d", len(contribs))
+	} else if contribs[0].ContributorID != contributor.ID {
+		t.Errorf("contributor ID: got %q, want %q", contribs[0].ContributorID, contributor.ID)
+	}
+
+	// Verify series junction table was written.
+	bookSeries, err := s.GetBookSeries(ctx, "batch-junc-1")
+	if err != nil {
+		t.Fatalf("GetBookSeries: %v", err)
+	}
+	if len(bookSeries) != 1 {
+		t.Errorf("expected 1 series, got %d", len(bookSeries))
+	} else if bookSeries[0].SeriesID != series.ID {
+		t.Errorf("series ID: got %q, want %q", bookSeries[0].SeriesID, series.ID)
+	}
+
+	// Verify genre junction table was written.
+	genreIDs, err := s.GetGenreIDsForBook(ctx, "batch-junc-1")
+	if err != nil {
+		t.Fatalf("GetGenreIDsForBook: %v", err)
+	}
+	if len(genreIDs) != 1 {
+		t.Errorf("expected 1 genre, got %d", len(genreIDs))
+	} else if genreIDs[0] != "genre-fantasy" {
+		t.Errorf("genre ID: got %q, want %q", genreIDs[0], "genre-fantasy")
+	}
+}
+
+// TestBatchWriter_FlushUpdatesJunctionTablesForExistingBook verifies that when a
+// book already exists in the database (ErrAlreadyExists), the batch writer still
+// writes junction table relationships. This covers the case where books were
+// originally created before junction-table writing was added to createBookTx.
+func TestBatchWriter_FlushUpdatesJunctionTablesForExistingBook(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Create a contributor and series.
+	contributor, err := s.GetOrCreateContributor(ctx, "Brandon Sanderson")
+	if err != nil {
+		t.Fatalf("GetOrCreateContributor: %v", err)
+	}
+
+	series, err := s.GetOrCreateSeries(ctx, "Stormlight Archive")
+	if err != nil {
+		t.Fatalf("GetOrCreateSeries: %v", err)
+	}
+
+	now := time.Now()
+	genre := &domain.Genre{
+		Syncable: domain.Syncable{
+			ID:        "genre-epic-fantasy",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		Name:     "Epic Fantasy",
+		Slug:     "epic-fantasy",
+		Path:     "/epic-fantasy",
+		IsSystem: true,
+	}
+	if err := s.CreateGenre(ctx, genre); err != nil {
+		t.Fatalf("CreateGenre: %v", err)
+	}
+
+	// Step 1: Create book WITHOUT junction tables (simulates old code).
+	bookNoJunctions := makeTestBook("batch-existing-1", "The Way of Kings", "/books/twok")
+	if err := s.CreateBook(ctx, bookNoJunctions); err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	// Verify junction tables are empty.
+	contribs, _ := s.GetBookContributors(ctx, "batch-existing-1")
+	if len(contribs) != 0 {
+		t.Fatalf("expected 0 contributors before fix, got %d", len(contribs))
+	}
+	bookSeries, _ := s.GetBookSeries(ctx, "batch-existing-1")
+	if len(bookSeries) != 0 {
+		t.Fatalf("expected 0 series before fix, got %d", len(bookSeries))
+	}
+
+	// Step 2: Try to create the same book via batch writer WITH junction data.
+	// This simulates a rescan after the junction-table fix was deployed.
+	bookWithJunctions := makeTestBook("batch-existing-1", "The Way of Kings", "/books/twok")
+	bookWithJunctions.Contributors = []domain.BookContributor{
+		{
+			ContributorID: contributor.ID,
+			Roles:         []domain.ContributorRole{domain.RoleAuthor},
+		},
+	}
+	bookWithJunctions.Series = []domain.BookSeries{
+		{
+			SeriesID: series.ID,
+			Sequence: "1",
+		},
+	}
+	bookWithJunctions.GenreIDs = []string{"genre-epic-fantasy"}
+
+	bw := s.NewBatchWriter(100)
+	if err := bw.CreateBook(ctx, bookWithJunctions); err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	if err := bw.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Step 3: Verify junction tables were written despite ErrAlreadyExists.
+	contribs, err = s.GetBookContributors(ctx, "batch-existing-1")
+	if err != nil {
+		t.Fatalf("GetBookContributors: %v", err)
+	}
+	if len(contribs) != 1 {
+		t.Errorf("expected 1 contributor after fix, got %d", len(contribs))
+	} else if contribs[0].ContributorID != contributor.ID {
+		t.Errorf("contributor ID: got %q, want %q", contribs[0].ContributorID, contributor.ID)
+	}
+
+	bookSeries, err = s.GetBookSeries(ctx, "batch-existing-1")
+	if err != nil {
+		t.Fatalf("GetBookSeries: %v", err)
+	}
+	if len(bookSeries) != 1 {
+		t.Errorf("expected 1 series after fix, got %d", len(bookSeries))
+	} else if bookSeries[0].SeriesID != series.ID {
+		t.Errorf("series ID: got %q, want %q", bookSeries[0].SeriesID, series.ID)
+	}
+
+	genreIDs, err := s.GetGenreIDsForBook(ctx, "batch-existing-1")
+	if err != nil {
+		t.Fatalf("GetGenreIDsForBook: %v", err)
+	}
+	if len(genreIDs) != 1 {
+		t.Errorf("expected 1 genre after fix, got %d", len(genreIDs))
+	} else if genreIDs[0] != "genre-epic-fantasy" {
+		t.Errorf("genre ID: got %q, want %q", genreIDs[0], "genre-epic-fantasy")
+	}
+}

--- a/internal/store/sqlite/books.go
+++ b/internal/store/sqlite/books.go
@@ -647,6 +647,35 @@ func (s *Store) UpdateBook(ctx context.Context, book *domain.Book) error {
 	return nil
 }
 
+// updateBookJunctionTables writes contributor, series, and genre junction rows
+// for an existing book. Used by the batch writer when a book already exists but
+// may have been created before junction-table writing was added.
+func (s *Store) updateBookJunctionTables(ctx context.Context, book *domain.Book) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if len(book.Contributors) > 0 {
+		if err := setBookContributorsTx(ctx, tx, book.ID, book.Contributors); err != nil {
+			return fmt.Errorf("set contributors: %w", err)
+		}
+	}
+	if len(book.Series) > 0 {
+		if err := setBookSeriesTx(ctx, tx, book.ID, book.Series); err != nil {
+			return fmt.Errorf("set series: %w", err)
+		}
+	}
+	if len(book.GenreIDs) > 0 {
+		if err := setBookGenresTx(ctx, tx, book.ID, book.GenreIDs); err != nil {
+			return fmt.Errorf("set genres: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
 // DeleteBook performs a soft delete by setting deleted_at and updated_at.
 // Returns store.ErrNotFound if the book does not exist or is already deleted.
 func (s *Store) DeleteBook(ctx context.Context, id string) error {


### PR DESCRIPTION
Fixes #85.

## Root Causes

### Bug 1: Junction tables skipped on rescan for existing books
`BatchWriter.Flush()` was catching `ErrAlreadyExists` and skipping the entire book — including its junction table writes. Books added before v0.6.4 (when junction writing was introduced) would never get their relationships populated on rescan.

**Fix:** On `ErrAlreadyExists`, call new `updateBookJunctionTables()` to write contributor/series/genre rows for the existing book.

### Bug 2: Post-flush operations ran before Flush()
`saveToDatabase()` in the scanner was calling `AdminAddBookToCollection()` and emitting SSE events *before* `batchWriter.Flush()` — book rows did not yet exist in the DB, causing silent FK violations.

**Fix:** Restructured `saveToDatabase()` to flush first, then run all post-flush operations.

## Changes
- `internal/store/sqlite/batch.go` — call `updateBookJunctionTables()` on `ErrAlreadyExists`
- `internal/store/sqlite/books.go` — new `updateBookJunctionTables()` method
- `internal/scanner/scanner.go` — flush before post-flush operations
- `internal/store/sqlite/batch_junctions_test.go` — 2 new tests (new book junctions, existing book junction update)