### PR TITLE
🐛 Bump updated_at when writing junction tables so delta sync picks up changes (#87)

### DIFF
--- a/internal/store/sqlite/batch_junctions_test.go
+++ b/internal/store/sqlite/batch_junctions_test.go
@@ -215,3 +215,49 @@ func TestBatchWriter_FlushUpdatesJunctionTablesForExistingBook(t *testing.T) {
 		t.Errorf("genre ID: got %q, want %q", genreIDs[0], "genre-epic-fantasy")
 	}
 }
+
+func TestUpdateBookJunctionTables_BumpsUpdatedAt(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Create a contributor.
+	contributor, err := s.GetOrCreateContributor(ctx, "Patrick Rothfuss")
+	if err != nil {
+		t.Fatalf("GetOrCreateContributor: %v", err)
+	}
+
+	// Create a book with a known timestamp in the past.
+	book := makeTestBook("bump-test-1", "The Name of the Wind", "/books/notw")
+	book.UpdatedAt = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	book.CreatedAt = book.UpdatedAt
+	if err := s.CreateBook(ctx, book); err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	// Record the original updated_at.
+	original, err := s.GetBook(ctx, "bump-test-1", "")
+	if err != nil {
+		t.Fatalf("GetBook before: %v", err)
+	}
+	originalUpdatedAt := original.UpdatedAt
+
+	// Call updateBookJunctionTables with contributor data.
+	book.Contributors = []domain.BookContributor{
+		{
+			ContributorID: contributor.ID,
+			Roles:         []domain.ContributorRole{domain.RoleAuthor},
+		},
+	}
+	if err := s.updateBookJunctionTables(ctx, book); err != nil {
+		t.Fatalf("updateBookJunctionTables: %v", err)
+	}
+
+	// Verify updated_at was bumped.
+	after, err := s.GetBook(ctx, "bump-test-1", "")
+	if err != nil {
+		t.Fatalf("GetBook after: %v", err)
+	}
+	if !after.UpdatedAt.After(originalUpdatedAt) {
+		t.Errorf("expected updated_at to be bumped: before=%v, after=%v", originalUpdatedAt, after.UpdatedAt)
+	}
+}

--- a/internal/store/sqlite/books.go
+++ b/internal/store/sqlite/books.go
@@ -673,6 +673,13 @@ func (s *Store) updateBookJunctionTables(ctx context.Context, book *domain.Book)
 		}
 	}
 
+	// Bump updated_at so delta sync picks up junction-table changes.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE books SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?`,
+		book.ID); err != nil {
+		return fmt.Errorf("bump updated_at: %w", err)
+	}
+
 	return tx.Commit()
 }
 


### PR DESCRIPTION
Fixes #87.

## Problem
`updateBookJunctionTables()` wrote contributor/series/genre junction rows but did not update `books.updated_at`. The delta sync endpoint uses `updated_at` to filter changed books — so clients never re-synced books whose junction tables were repaired/populated, leaving contributors, series, and genres missing on the client.

## Fix
`updateBookJunctionTables()` now bumps `books.updated_at` inside the same transaction as the junction table writes.

## Test
Updated `batch_junctions_test.go` — verifies that after `updateBookJunctionTables()` runs, the book row has a fresh `updated_at` that is strictly greater than the original.