### PR TITLE
✨ add POST /api/v1/transcode/cancel/{jobId} endpoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -224,6 +224,7 @@ func (s *Server) registerRoutes() {
 	s.registerSocialRoutes()
 	s.registerProfileRoutes()
 	s.registerPlaybackRoutes()
+	s.registerTranscodeRoutes()
 	s.registerSettingsRoutes()
 	s.registerGenreRoutes()
 	s.registerTagRoutes()

--- a/internal/api/transcode_handlers.go
+++ b/internal/api/transcode_handlers.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/listenupapp/listenup-server/internal/store"
+)
+
+func (s *Server) registerTranscodeRoutes() {
+	huma.Register(s.api, huma.Operation{
+		OperationID:   "cancelTranscodeJob",
+		Method:        http.MethodPost,
+		Path:          "/api/v1/transcode/cancel/{jobId}",
+		Summary:       "Cancel a transcode job",
+		Description:   "Cancels a pending or running transcode job. Returns 404 if the job does not exist, is already completed, or is already cancelled.",
+		Tags:          []string{"Transcode"},
+		Security:      []map[string][]string{{"bearer": {}}},
+		DefaultStatus: http.StatusNoContent,
+	}, s.handleCancelTranscode)
+}
+
+// CancelTranscodeInput contains parameters for cancelling a transcode job.
+type CancelTranscodeInput struct {
+	Authorization string `header:"Authorization"`
+	JobID         string `path:"jobId" doc:"Transcode job ID"`
+}
+
+// CancelTranscodeOutput is the empty 204 response.
+type CancelTranscodeOutput struct{}
+
+func (s *Server) handleCancelTranscode(ctx context.Context, input *CancelTranscodeInput) (*CancelTranscodeOutput, error) {
+	if _, err := GetUserID(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := s.services.Transcode.CancelJob(ctx, input.JobID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, huma.Error404NotFound("transcode job not found or not cancellable")
+		}
+		return nil, huma.Error500InternalServerError("failed to cancel transcode job: " + err.Error())
+	}
+
+	return &CancelTranscodeOutput{}, nil
+}

--- a/internal/api/transcode_handlers_test.go
+++ b/internal/api/transcode_handlers_test.go
@@ -1,0 +1,322 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"encoding/hex"
+	"encoding/json/v2"
+	"log/slog"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/go-chi/chi/v5"
+	"github.com/listenupapp/listenup-server/internal/auth"
+	"github.com/listenupapp/listenup-server/internal/config"
+	"github.com/listenupapp/listenup-server/internal/domain"
+	"github.com/listenupapp/listenup-server/internal/dto"
+	"github.com/listenupapp/listenup-server/internal/id"
+	"github.com/listenupapp/listenup-server/internal/service"
+	"github.com/listenupapp/listenup-server/internal/sse"
+	"github.com/listenupapp/listenup-server/internal/store/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// transcodeTestServer wraps the API server for transcode endpoint testing.
+type transcodeTestServer struct {
+	*Server
+	api          humatest.TestAPI
+	tokenService *auth.TokenService
+}
+
+// setupTranscodeAPITestServer creates a test server with transcode support.
+func setupTranscodeAPITestServer(t *testing.T) *transcodeTestServer {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "listenup-transcode-api-test-*")
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	cachePath := filepath.Join(tmpDir, "cache")
+
+	st, err := sqlite.Open(dbPath, nil)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Name:      "Test Server",
+			LocalURL:  "http://localhost:8080",
+			RemoteURL: "",
+		},
+		Auth: config.AuthConfig{
+			AccessTokenDuration:  15 * time.Minute,
+			RefreshTokenDuration: 30 * 24 * time.Hour,
+		},
+	}
+
+	authKey, err := auth.LoadOrGenerateKey(tmpDir)
+	require.NoError(t, err)
+	cfg.Auth.AccessTokenKey = authKey
+
+	tokenService, err := auth.NewTokenService(
+		hex.EncodeToString(authKey),
+		cfg.Auth.AccessTokenDuration,
+		cfg.Auth.RefreshTokenDuration,
+	)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	sseManager := sse.NewManager(logger)
+	enricher := dto.NewEnricher(st)
+
+	sessionService := service.NewSessionService(st, tokenService, logger)
+	instanceService := service.NewInstanceService(st, logger, cfg)
+	authService := service.NewAuthService(st, tokenService, sessionService, instanceService, logger)
+	syncService := service.NewSyncService(st, logger)
+	shelfService := service.NewShelfService(st, sseManager, logger)
+	inboxService := service.NewInboxService(st, enricher, sseManager, logger)
+	settingsService := service.NewSettingsService(st, inboxService, logger)
+	absImportService := service.NewABSImportService(st, logger)
+
+	// Transcode service with workers disabled (no FFmpeg needed for unit tests).
+	transcodeService, err := service.NewTranscodeService(st, sseManager, config.TranscodeConfig{
+		Enabled:       false,
+		CachePath:     cachePath,
+		MaxConcurrent: 1,
+	}, logger)
+	require.NoError(t, err)
+
+	services := &Services{
+		Instance:  instanceService,
+		Auth:      authService,
+		Sync:      syncService,
+		Shelf:     shelfService,
+		Settings:  settingsService,
+		Inbox:     inboxService,
+		ABSImport: absImportService,
+		Transcode: transcodeService,
+	}
+
+	router := chi.NewRouter()
+	router.Use(authMiddleware(services.Auth))
+
+	humaConfig := huma.DefaultConfig("ListenUp API Test", "1.0.0")
+	humaConfig.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"bearer": {
+			Type:         "http",
+			Scheme:       "bearer",
+			BearerFormat: "PASETO",
+		},
+	}
+	humaConfig.Transformers = append(humaConfig.Transformers, EnvelopeTransformer)
+
+	api := humachi.New(router, humaConfig)
+	RegisterErrorHandler()
+
+	s := &Server{
+		store:           st,
+		services:        services,
+		router:          router,
+		api:             api,
+		logger:          logger,
+		authRateLimiter: NewRateLimiter(100, time.Minute, 50),
+	}
+
+	s.registerHealthRoutes()
+	s.registerInstanceRoutes()
+	s.registerAuthRoutes()
+	s.registerTranscodeRoutes()
+
+	_, err = services.Instance.InitializeInstance(context.Background())
+	require.NoError(t, err)
+
+	testAPI := humatest.Wrap(t, api)
+
+	t.Cleanup(func() {
+		_ = st.Close()
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	return &transcodeTestServer{
+		Server:       s,
+		api:          testAPI,
+		tokenService: tokenService,
+	}
+}
+
+// createTranscodeTestUser creates a user and returns the access token.
+func (ts *transcodeTestServer) createTranscodeTestUser(t *testing.T) string {
+	t.Helper()
+
+	resp := ts.api.Post("/api/v1/auth/setup", map[string]any{
+		"email":      "admin@test.com",
+		"password":   "TestPassword123!",
+		"first_name": "Test",
+		"last_name":  "Admin",
+	})
+	require.Equal(t, http.StatusOK, resp.Code, "Setup failed: %s", resp.Body.String())
+
+	var envelope testEnvelope[AuthResponse]
+	err := json.Unmarshal(resp.Body.Bytes(), &envelope)
+	require.NoError(t, err)
+
+	return envelope.Data.AccessToken
+}
+
+// seedTranscodeJob inserts a transcode job directly into the store for testing.
+func (ts *transcodeTestServer) seedTranscodeJob(t *testing.T, status domain.TranscodeStatus) string {
+	t.Helper()
+	ctx := context.Background()
+
+	bookID, err := id.Generate("bk")
+	require.NoError(t, err)
+	audioFileID, err := id.Generate("af")
+	require.NoError(t, err)
+	jobID, err := id.Generate("tj")
+	require.NoError(t, err)
+
+	// Books table has FK constraints; insert a minimal book first.
+	now := time.Now()
+	book := &domain.Book{
+		Syncable: domain.Syncable{
+			ID:        bookID,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		Title:         "Test Book",
+		Path:          "/test/" + bookID,
+		TotalDuration: 300000,
+		TotalSize:     1024000,
+		ScannedAt:     now,
+		AudioFiles: []domain.AudioFileInfo{
+			{
+				ID:       audioFileID,
+				Path:     "/test/source.m4a",
+				Filename: "source.m4a",
+				Duration: 300000,
+				Size:     1024000,
+			},
+		},
+	}
+	require.NoError(t, ts.store.CreateBook(ctx, book))
+
+	job := &domain.TranscodeJob{
+		ID:          jobID,
+		BookID:      bookID,
+		AudioFileID: audioFileID,
+		SourcePath:  "/test/source.m4a",
+		SourceCodec: "eac3",
+		SourceHash:  "test-hash",
+		OutputCodec: "aac",
+		Variant:     domain.TranscodeVariantStereo,
+		Status:      status,
+		Priority:    1,
+		CreatedAt:   now,
+	}
+
+	if status == domain.TranscodeStatusRunning {
+		t := now
+		job.StartedAt = &t
+	}
+	if status == domain.TranscodeStatusCompleted {
+		t1 := now
+		t2 := now
+		job.StartedAt = &t1
+		job.CompletedAt = &t2
+		job.OutputPath = "/test/output"
+		job.OutputSize = 1024
+		job.Progress = 100
+	}
+	if status == domain.TranscodeStatusCancelled {
+		t1 := now
+		t2 := now
+		job.StartedAt = &t1
+		job.CompletedAt = &t2
+	}
+
+	require.NoError(t, ts.store.CreateTranscodeJob(ctx, job))
+	return jobID
+}
+
+// === Tests ===
+
+func TestCancelTranscode_ActivePendingJob(t *testing.T) {
+	t.Parallel()
+	ts := setupTranscodeAPITestServer(t)
+	token := ts.createTranscodeTestUser(t)
+
+	jobID := ts.seedTranscodeJob(t, domain.TranscodeStatusPending)
+
+	resp := ts.api.Post("/api/v1/transcode/cancel/"+jobID, struct{}{},
+		"Authorization: Bearer "+token)
+
+	assert.Equal(t, http.StatusNoContent, resp.Code, resp.Body.String())
+}
+
+func TestCancelTranscode_ActiveRunningJob(t *testing.T) {
+	t.Parallel()
+	ts := setupTranscodeAPITestServer(t)
+	token := ts.createTranscodeTestUser(t)
+
+	jobID := ts.seedTranscodeJob(t, domain.TranscodeStatusRunning)
+
+	resp := ts.api.Post("/api/v1/transcode/cancel/"+jobID, struct{}{},
+		"Authorization: Bearer "+token)
+
+	assert.Equal(t, http.StatusNoContent, resp.Code, resp.Body.String())
+}
+
+func TestCancelTranscode_NonExistentJob(t *testing.T) {
+	t.Parallel()
+	ts := setupTranscodeAPITestServer(t)
+	token := ts.createTranscodeTestUser(t)
+
+	resp := ts.api.Post("/api/v1/transcode/cancel/tj_doesnotexist", struct{}{},
+		"Authorization: Bearer "+token)
+
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestCancelTranscode_AlreadyCancelled(t *testing.T) {
+	t.Parallel()
+	ts := setupTranscodeAPITestServer(t)
+	token := ts.createTranscodeTestUser(t)
+
+	jobID := ts.seedTranscodeJob(t, domain.TranscodeStatusCancelled)
+
+	// Idempotent: second cancel returns 404.
+	resp := ts.api.Post("/api/v1/transcode/cancel/"+jobID, struct{}{},
+		"Authorization: Bearer "+token)
+
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestCancelTranscode_AlreadyCompleted(t *testing.T) {
+	t.Parallel()
+	ts := setupTranscodeAPITestServer(t)
+	token := ts.createTranscodeTestUser(t)
+
+	jobID := ts.seedTranscodeJob(t, domain.TranscodeStatusCompleted)
+
+	resp := ts.api.Post("/api/v1/transcode/cancel/"+jobID, struct{}{},
+		"Authorization: Bearer "+token)
+
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestCancelTranscode_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	ts := setupTranscodeAPITestServer(t)
+
+	// No Authorization header — expect 401.
+	resp := ts.api.Post("/api/v1/transcode/cancel/tj_any", struct{}{})
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+}

--- a/internal/domain/transcode.go
+++ b/internal/domain/transcode.go
@@ -11,6 +11,7 @@ const (
 	TranscodeStatusRunning   TranscodeStatus = "running"
 	TranscodeStatusCompleted TranscodeStatus = "completed"
 	TranscodeStatusFailed    TranscodeStatus = "failed"
+	TranscodeStatusCancelled TranscodeStatus = "cancelled"
 )
 
 // TranscodeVariant identifies the output format variant.
@@ -118,4 +119,17 @@ func (j *TranscodeJob) BumpPriority() {
 	if j.Priority < 10 {
 		j.Priority = 10
 	}
+}
+
+// MarkCancelled transitions the job to cancelled state.
+func (j *TranscodeJob) MarkCancelled() {
+	j.Status = TranscodeStatusCancelled
+	now := time.Now()
+	j.CompletedAt = &now
+}
+
+// IsActive returns true if the job is in a state that can be cancelled
+// (pending or running).
+func (j *TranscodeJob) IsActive() bool {
+	return j.Status == TranscodeStatusPending || j.Status == TranscodeStatusRunning
 }

--- a/internal/service/transcode.go
+++ b/internal/service/transcode.go
@@ -44,6 +44,10 @@ type TranscodeService struct {
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
 	jobNotify chan struct{} // Signal that new jobs are available
+
+	// activeJobCancels maps jobID → per-job cancel func for running FFmpeg processes.
+	// Populated when a worker starts a job; cleared when the job finishes or is cancelled.
+	activeJobCancels sync.Map
 }
 
 // NewTranscodeService creates a new transcode service.
@@ -260,6 +264,36 @@ func (s *TranscodeService) BumpPriority(ctx context.Context, jobID string) error
 	return nil
 }
 
+// CancelJob marks a transcode job as cancelled and stops the FFmpeg process if running.
+// Returns store.ErrNotFound if the job does not exist, is already completed, or is already cancelled
+// (idempotent: a second cancel attempt returns 404 rather than succeeding silently).
+func (s *TranscodeService) CancelJob(ctx context.Context, jobID string) error {
+	job, err := s.store.GetTranscodeJob(ctx, jobID)
+	if err != nil {
+		return fmt.Errorf("get transcode job: %w", err)
+	}
+
+	if !job.IsActive() {
+		// Already completed, failed, or cancelled — treat as not found per contract.
+		return store.ErrNotFound
+	}
+
+	// Persist cancellation before signalling the worker, so the worker's deferred
+	// goroutine sees the cancelled status and skips the failure path.
+	job.MarkCancelled()
+	if err := s.store.UpdateTranscodeJob(ctx, job); err != nil {
+		return fmt.Errorf("mark job cancelled: %w", err)
+	}
+
+	// Signal the FFmpeg process to exit if it is currently running.
+	if cancelFn, ok := s.activeJobCancels.Load(jobID); ok {
+		cancelFn.(context.CancelFunc)()
+	}
+
+	s.logger.Info("transcode job cancelled", slog.String("job_id", jobID))
+	return nil
+}
+
 // GetTranscodePath returns the path to the HLS directory if transcoding is complete.
 func (s *TranscodeService) GetTranscodePath(ctx context.Context, audioFileID string) (string, bool) {
 	job, err := s.store.GetTranscodeJobByAudioFile(ctx, audioFileID)
@@ -425,9 +459,26 @@ func (s *TranscodeService) processNextJob(workerID int) {
 		slog.String("source", job.SourcePath),
 	)
 
+	// Create a per-job context so CancelJob can stop FFmpeg without killing the
+	// entire service.  Store the cancel func before starting; remove it when done.
+	jobCtx, jobCancel := context.WithCancel(ctx)
+	s.activeJobCancels.Store(job.ID, jobCancel)
+	defer func() {
+		jobCancel()
+		s.activeJobCancels.Delete(job.ID)
+	}()
+
 	// Execute transcode
-	outputPath, err := s.executeTranscode(ctx, job)
+	outputPath, err := s.executeTranscode(jobCtx, job)
 	if err != nil {
+		// If the job was cancelled, mark it cancelled rather than failed.
+		if jobCtx.Err() != nil {
+			job, storeErr := s.store.GetTranscodeJob(ctx, job.ID)
+			if storeErr == nil && job.Status == domain.TranscodeStatusCancelled {
+				// Already marked by CancelJob; nothing more to do.
+				return
+			}
+		}
 		s.handleTranscodeError(ctx, job, err)
 		return
 	}


### PR DESCRIPTION
## Summary

Adds the `POST /api/v1/transcode/cancel/{jobId}` endpoint to support W8 Phase D's user-cancel-during-WAITING_FOR_SERVER flow on the client.

- 204 on successful cancellation of an active job (pending or running).
- 404 on non-existent job, already-completed job, or already-cancelled job (idempotent).
- Bearer-authenticated standard route.
- Server marks the transcode job as cancelled; the FFmpeg worker cleanly exits at its next progress checkpoint via a per-job `context.WithCancel`.
- Server does NOT emit `transcode.complete` for cancelled jobs (client's late-event tolerance code is a defense-in-depth net).

### Changes

- `domain/transcode.go` — adds `TranscodeStatusCancelled`, `MarkCancelled()`, `IsActive()`.
- `service/transcode.go` — adds `activeJobCancels sync.Map` for per-job cancel tracking; adds `CancelJob(ctx, jobID)` method.
- `api/transcode_handlers.go` — new handler + Huma operation registration.
- `api/server.go` — registers `registerTranscodeRoutes()` in the route tree.

This is the only server-side change required for W8 Phase D. The client PR follows.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./...` green (all packages, 0 regressions).
- [ ] `act -W .github/workflows/ci.yml` — **blocked**: `act` has never been configured on this machine and requires interactive first-time image selection (no `actrc` file). Cannot run non-interactively. Remote CI will validate on PR open.
- [ ] Manual smoke: POST to the endpoint with an active jobId, confirm 204; observe FFmpeg worker exits.

## Successor

Client PR (W8 Phase D) consumes this endpoint via `PlaybackApiContract.cancelTranscode(jobId)`.