### PR TITLE
🎨 gofmt -w (fix formatting drift on main)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,10 +43,10 @@ type Server struct {
 	onInstanceUpdated         func(*domain.Instance)
 
 	// Workers and indexer for /health derived component checks.
-	indexer      *asyncindexer.Indexer
-	fileWatcher  lastTicker
-	sessionJob   lastTicker
-	eventLogJob  lastTicker
+	indexer     *asyncindexer.Indexer
+	fileWatcher lastTicker
+	sessionJob  lastTicker
+	eventLogJob lastTicker
 }
 
 // SetOnInstanceUpdated registers a callback invoked when instance settings change.

--- a/internal/backup/options.go
+++ b/internal/backup/options.go
@@ -80,11 +80,11 @@ func (s MergeStrategy) Valid() bool {
 
 // BackupResult contains the outcome of a backup operation.
 type BackupResult struct {
-	Path     string                 `json:"path"`
-	Size     int64                  `json:"size"`
-	Counts   manifest.EntityCounts  `json:"counts"`
-	Duration time.Duration          `json:"duration"`
-	Checksum string                 `json:"checksum"`
+	Path     string                `json:"path"`
+	Size     int64                 `json:"size"`
+	Counts   manifest.EntityCounts `json:"counts"`
+	Duration time.Duration         `json:"duration"`
+	Checksum string                `json:"checksum"`
 }
 
 // BackupInfo describes an existing backup.

--- a/internal/search/asyncindexer/asyncindexer_test.go
+++ b/internal/search/asyncindexer/asyncindexer_test.go
@@ -12,12 +12,12 @@ import (
 // noopSearchIndexer is a no-op implementation of store.SearchIndexer for tests.
 type noopSearchIndexer struct{}
 
-func (noopSearchIndexer) IndexBook(_ context.Context, _ *domain.Book) error              { return nil }
-func (noopSearchIndexer) DeleteBook(_ context.Context, _ string) error                   { return nil }
+func (noopSearchIndexer) IndexBook(_ context.Context, _ *domain.Book) error               { return nil }
+func (noopSearchIndexer) DeleteBook(_ context.Context, _ string) error                    { return nil }
 func (noopSearchIndexer) IndexContributor(_ context.Context, _ *domain.Contributor) error { return nil }
-func (noopSearchIndexer) DeleteContributor(_ context.Context, _ string) error            { return nil }
-func (noopSearchIndexer) IndexSeries(_ context.Context, _ *domain.Series) error          { return nil }
-func (noopSearchIndexer) DeleteSeries(_ context.Context, _ string) error                 { return nil }
+func (noopSearchIndexer) DeleteContributor(_ context.Context, _ string) error             { return nil }
+func (noopSearchIndexer) IndexSeries(_ context.Context, _ *domain.Series) error           { return nil }
+func (noopSearchIndexer) DeleteSeries(_ context.Context, _ string) error                  { return nil }
 
 func TestIndexer_LastTickAdvances(t *testing.T) {
 	t.Parallel()

--- a/internal/service/collection.go
+++ b/internal/service/collection.go
@@ -393,9 +393,9 @@ func (s *CollectionService) AdminDeleteCollection(ctx context.Context, collectio
 
 // AddBookToCollectionResult carries per-book outcome for admin batch-add.
 type AddBookToCollectionResult struct {
-	BookID       string
+	BookID         string
 	WasUncollected bool // true if the book was public before this operation
-	Added        bool   // false if the store returned an error
+	Added          bool // false if the store returned an error
 }
 
 // AdminAddBooksToCollectionResult is the output of AdminAddBooksToCollection.

--- a/internal/service/library.go
+++ b/internal/service/library.go
@@ -82,10 +82,10 @@ func (s *LibraryService) GetLibraryStatus(ctx context.Context, userID string) (*
 
 // SetupLibraryInput is the input for setting up a library.
 type SetupLibraryInput struct {
-	AdminID    string
-	Name       string
-	ScanPaths  []string // At least one path required.
-	SkipInbox  *bool
+	AdminID   string
+	Name      string
+	ScanPaths []string // At least one path required.
+	SkipInbox *bool
 }
 
 // SetupLibrary creates the initial library if none exists.

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -465,9 +465,9 @@ func (s *SyncService) GetSeriesForSync(ctx context.Context, userID string, param
 // Used as the return type for GetActiveSessionsForUser and GetReadingSessionsForUser
 // so callers do not need to perform secondary lookups against the store.
 type SessionWithUser struct {
-	Session  *domain.BookReadingSession
-	User     *domain.User
-	Profile  *domain.UserProfile
+	Session *domain.BookReadingSession
+	User    *domain.User
+	Profile *domain.UserProfile
 }
 
 // GetActiveSessionsForUser returns all currently active reading sessions for books

--- a/internal/store/sqlite/batch_test.go
+++ b/internal/store/sqlite/batch_test.go
@@ -56,4 +56,3 @@ func TestBatchWriter_EmptyFlushNoError(t *testing.T) {
 		t.Fatalf("Flush: %v", err)
 	}
 }
-


### PR DESCRIPTION
## Summary

`gofmt -w` across the repo to clear pre-existing formatting drift on main. Server CI's `Lint / Check formatting` step has been failing since 2026-04-30 (4 of last 5 main pushes show CI failure) due to column-aligned struct field re-formatting that the dev-machine `gofmt` produces but a slightly older toolchain version didn't. This PR realigns 7 files to the canonical `gofmt` output. Pure formatting; no logic changes.

This unblocks the W8 Phase D server PR (#91) which was inheriting these failures despite touching none of these files.

## Files

- \`internal/api/server.go\`
- \`internal/backup/options.go\`
- \`internal/search/asyncindexer/asyncindexer_test.go\`
- \`internal/service/collection.go\`
- \`internal/service/library.go\`
- \`internal/service/sync.go\`
- \`internal/store/sqlite/batch_test.go\`

## Test plan

- [x] \`gofmt -l .\` returns empty after applying.
- [x] \`GOEXPERIMENT=jsonv2 go test ./... -short\` — all packages green; zero failures.
- [ ] Remote CI lint step turns green.

## Successor

Server PR #91 (W8 Phase D cancelTranscode endpoint) lands on top, then the Phase D client PR consumes the new endpoint.